### PR TITLE
D48720 acpi: Suspend-to-idle support (S0i)

### DIFF
--- a/sys/dev/acpica/acpi.c
+++ b/sys/dev/acpica/acpi.c
@@ -3410,11 +3410,7 @@ do_idle(struct acpi_softc *sc, enum acpi_sleep_state *slp_state,
     // TODO Explain what we're doing here.
     intr_enable_src(AcpiGbl_FADT.SciInterrupt);
 
-    // TODO Make this better.
-    if (sc->acpi_spmc_device != NULL)
-	cpu_mwait(MWAIT_INTRBREAK, MWAIT_C4);
-    else
-	cpu_idle(0);
+    cpu_idle(0);
 
     intr_resume(false);
     intr_restore(intr);

--- a/sys/dev/acpica/acpi.c
+++ b/sys/dev/acpica/acpi.c
@@ -157,7 +157,7 @@ static ACPI_STATUS acpi_probe_child(ACPI_HANDLE handle, UINT32 level,
 		    void *context, void **status);
 static void	acpi_sleep_enable(void *arg);
 static ACPI_STATUS acpi_sleep_disable(struct acpi_softc *sc);
-static ACPI_STATUS acpi_EnterSleepState(struct acpi_softc *sc, int state);
+static ACPI_STATUS acpi_EnterSleepState(struct acpi_softc *sc, enum sleep_type stype);
 static void	acpi_shutdown_final(void *arg, int howto);
 static void	acpi_enable_fixed_events(struct acpi_softc *sc);
 static void	acpi_resync_clock(struct acpi_softc *sc);
@@ -3100,22 +3100,22 @@ acpi_sleep_force(void *arg)
  * acks are in.
  */
 int
-acpi_ReqSleepState(struct acpi_softc *sc, int state)
+acpi_ReqSleepState(struct acpi_softc *sc, enum sleep_type stype)
 {
 #if defined(__amd64__) || defined(__i386__)
     struct apm_clone_data *clone;
     ACPI_STATUS status;
 
-    if (state < ACPI_STATE_S1 || state > ACPI_S_STATES_MAX)
+    if (stype < ACPI_STATE_S1 || stype > ACPI_S_STATES_MAX)
 	return (EINVAL);
-    if (!acpi_sleep_states[state])
+    if (!acpi_sleep_states[stype])
 	return (EOPNOTSUPP);
 
     /*
      * If a reboot/shutdown/suspend request is already in progress or
      * suspend is blocked due to an upcoming shutdown, just return.
      */
-    if (rebooting || sc->acpi_next_sstate != 0 || suspend_blocked) {
+    if (rebooting || sc->acpi_next_sstate != AWAKE || suspend_blocked) {
 	return (0);
     }
 
@@ -3126,12 +3126,12 @@ acpi_ReqSleepState(struct acpi_softc *sc, int state)
 
     ACPI_LOCK(acpi);
 
-    sc->acpi_next_sstate = state;
+    sc->acpi_next_sstate = stype;
 
     /* S5 (soft-off) should be entered directly with no waiting. */
-    if (state == ACPI_STATE_S5) {
+    if (stype == POWEROFF) {
     	ACPI_UNLOCK(acpi);
-	status = acpi_EnterSleepState(sc, state);
+	status = acpi_EnterSleepState(sc, stype);
 	return (ACPI_SUCCESS(status) ? 0 : ENXIO);
     }
 
@@ -3147,7 +3147,7 @@ acpi_ReqSleepState(struct acpi_softc *sc, int state)
     /* If devd(8) is not running, immediately enter the sleep state. */
     if (!devctl_process_running()) {
 	ACPI_UNLOCK(acpi);
-	status = acpi_EnterSleepState(sc, state);
+	status = acpi_EnterSleepState(sc, stype);
 	return (ACPI_SUCCESS(status) ? 0 : ENXIO);
     }
 
@@ -3162,11 +3162,12 @@ acpi_ReqSleepState(struct acpi_softc *sc, int state)
     ACPI_UNLOCK(acpi);
 
     /* Now notify devd(8) also. */
-    acpi_UserNotify("Suspend", ACPI_ROOT_OBJECT, state);
+    acpi_UserNotify("Suspend", ACPI_ROOT_OBJECT, stype);
 
     return (0);
 #else
-    /* This platform does not support acpi suspend/resume. */
+    device_printf(sc->acpi_dev, "ACPI suspend not supported on this platform"
+	"(TODO suspend to idle should be, however)\n");
     return (EOPNOTSUPP);
 #endif
 }
@@ -3188,14 +3189,14 @@ acpi_AckSleepState(struct apm_clone_data *clone, int error)
     /* If no pending sleep state, return an error. */
     ACPI_LOCK(acpi);
     sc = clone->acpi_sc;
-    if (sc->acpi_next_sstate == 0) {
+    if (sc->acpi_next_sstate == AWAKE) {
     	ACPI_UNLOCK(acpi);
 	return (ENXIO);
     }
 
     /* Caller wants to abort suspend process. */
     if (error) {
-	sc->acpi_next_sstate = 0;
+	sc->acpi_next_sstate = AWAKE;
 	callout_stop(&sc->susp_force_to);
 	device_printf(sc->acpi_dev,
 	    "listener on %s cancelled the pending suspend\n",
@@ -3230,7 +3231,8 @@ acpi_AckSleepState(struct apm_clone_data *clone, int error)
     }
     return (ret);
 #else
-    /* This platform does not support acpi suspend/resume. */
+    device_printf(sc->acpi_dev, "ACPI suspend not supported on this platform"
+	"(TODO suspend to idle should be, however)\n");
     return (EOPNOTSUPP);
 #endif
 }
@@ -3276,27 +3278,117 @@ enum acpi_sleep_state {
     ACPI_SS_SLEPT,
 };
 
+static void
+do_standby(struct acpi_softc *sc, enum acpi_sleep_state *slp_state,
+    register_t intr)
+{
+    ACPI_STATUS status;
+
+    status = AcpiEnterSleepState(STANDBY);
+    intr_restore(intr);
+    AcpiLeaveSleepStatePrep(STANDBY);
+    if (ACPI_FAILURE(status)) {
+	device_printf(sc->acpi_dev, "AcpiEnterSleepState failed - %s\n",
+	    AcpiFormatException(status));
+	return;
+    }
+    *slp_state = ACPI_SS_SLEPT;
+}
+
+static void
+do_sleep(struct acpi_softc *sc, enum acpi_sleep_state *slp_state,
+    register_t intr, int state)
+{
+    int sleep_result;
+    ACPI_EVENT_STATUS power_button_status;
+
+    MPASS(state == ACPI_STATE_S3 || state == ACPI_STATE_S4);
+
+    sleep_result = acpi_sleep_machdep(sc, state);
+    acpi_wakeup_machdep(sc, state, sleep_result, 0);
+
+    if (sleep_result == 1 && state != ACPI_STATE_S4) {
+	/*
+	 * XXX According to ACPI specification SCI_EN bit should be restored
+	 * by ACPI platform (BIOS, firmware) to its pre-sleep state.
+	 * Unfortunately some BIOSes fail to do that and that leads to
+	 * unexpected and serious consequences during wake up like a system
+	 * getting stuck in SMI handlers.
+	 * This hack is picked up from Linux, which claims that it follows
+	 * Windows behavior.
+	 */
+	AcpiWriteBitRegister(ACPI_BITREG_SCI_ENABLE, ACPI_ENABLE_EVENT);
+    }
+
+    if (sleep_result == 1 && state == ACPI_STATE_S3) {
+	/*
+	 * Prevent misinterpretation of the wakeup by power button
+	 * as a request for power off.
+	 * Ideally we should post an appropriate wakeup event,
+	 * perhaps using acpi_event_power_button_wake or alike.
+	 *
+	 * Clearing of power button status after wakeup is mandated
+	 * by ACPI specification in section "Fixed Power Button".
+	 *
+	 * XXX As of ACPICA 20121114 AcpiGetEventStatus provides
+	 * status as 0/1 corresponding to inactive/active despite
+	 * its type being ACPI_EVENT_STATUS.  In other words,
+	 * we should not test for ACPI_EVENT_FLAG_SET for time being.
+	 */
+	if (ACPI_SUCCESS(AcpiGetEventStatus(ACPI_EVENT_POWER_BUTTON,
+	    &power_button_status)) && power_button_status != 0) {
+	    AcpiClearEvent(ACPI_EVENT_POWER_BUTTON);
+	    device_printf(sc->acpi_dev, "cleared fixed power button status\n");
+	}
+    }
+
+    intr_restore(intr);
+
+    /* call acpi_wakeup_machdep() again with interrupt enabled */
+    acpi_wakeup_machdep(sc, state, sleep_result, 1);
+
+    AcpiLeaveSleepStatePrep(state);
+
+    if (sleep_result == -1)
+	return;
+
+    /* Re-enable ACPI hardware on wakeup from sleep state 4. */
+    if (state == ACPI_STATE_S4)
+	AcpiEnable();
+    *slp_state = ACPI_SS_SLEPT;
+}
+
+static void
+do_idle(struct acpi_softc *sc, enum acpi_sleep_state *slp_state,
+    register_t intr)
+{
+    // TODO There's probably a bit more to this than this.
+
+    cpu_idle(0);
+
+    intr_restore(intr);
+    *slp_state = ACPI_SS_SLEPT;
+}
+
 /*
  * Enter the desired system sleep state.
  *
  * Currently we support S1-S5 but S4 is only S4BIOS
  */
 static ACPI_STATUS
-acpi_EnterSleepState(struct acpi_softc *sc, int state)
+acpi_EnterSleepState(struct acpi_softc *sc, enum sleep_type stype)
 {
     register_t intr;
     ACPI_STATUS status;
-    ACPI_EVENT_STATUS power_button_status;
     enum acpi_sleep_state slp_state;
-    int sleep_result;
 
     ACPI_FUNCTION_TRACE_U32((char *)(uintptr_t)__func__, state);
 
-    if (state < ACPI_STATE_S1 || state > ACPI_S_STATES_MAX)
+    if (stype < ACPI_STATE_S1 || stype > ACPI_S_STATES_MAX)
 	return_ACPI_STATUS (AE_BAD_PARAMETER);
-    if (!acpi_sleep_states[state]) {
+    if (!acpi_sleep_states[stype]) {
 	device_printf(sc->acpi_dev, "Sleep state S%d not supported by BIOS\n",
-	    state);
+	    stype);
 	return (AE_SUPPORT);
     }
 
@@ -3308,7 +3400,7 @@ acpi_EnterSleepState(struct acpi_softc *sc, int state)
 	return (status);
     }
 
-    if (state == ACPI_STATE_S5) {
+    if (stype == ACPI_STATE_S5) {
 	/*
 	 * Shut down cleanly and power off.  This will call us back through the
 	 * shutdown handlers.
@@ -3342,10 +3434,10 @@ acpi_EnterSleepState(struct acpi_softc *sc, int state)
 
     slp_state = ACPI_SS_NONE;
 
-    sc->acpi_sstate = state;
+    sc->acpi_sstate = stype;
 
     /* Enable any GPEs as appropriate and requested by the user. */
-    acpi_wake_prep_walk(state);
+    acpi_wake_prep_walk(stype);
     slp_state = ACPI_SS_GPE_SET;
 
     /*
@@ -3362,82 +3454,39 @@ acpi_EnterSleepState(struct acpi_softc *sc, int state)
     }
     slp_state = ACPI_SS_DEV_SUSPEND;
 
-    status = AcpiEnterSleepStatePrep(state);
-    if (ACPI_FAILURE(status)) {
-	device_printf(sc->acpi_dev, "AcpiEnterSleepStatePrep failed - %s\n",
-		      AcpiFormatException(status));
-	goto backout;
+    if (stype != SUSPEND_TO_IDLE) {
+	status = AcpiEnterSleepStatePrep(stype);
+	if (ACPI_FAILURE(status)) {
+	    device_printf(sc->acpi_dev, "AcpiEnterSleepStatePrep failed - %s\n",
+		AcpiFormatException(status));
+	    goto backout;
+	}
     }
     slp_state = ACPI_SS_SLP_PREP;
 
     if (sc->acpi_sleep_delay > 0)
 	DELAY(sc->acpi_sleep_delay * 1000000);
 
+    int state = stype; // TODO Sanitize this like in Ben's patch.
+
     suspendclock();
     intr = intr_disable();
-    if (state != ACPI_STATE_S1) {
-	sleep_result = acpi_sleep_machdep(sc, state);
-	acpi_wakeup_machdep(sc, state, sleep_result, 0);
-
-	/*
-	 * XXX According to ACPI specification SCI_EN bit should be restored
-	 * by ACPI platform (BIOS, firmware) to its pre-sleep state.
-	 * Unfortunately some BIOSes fail to do that and that leads to
-	 * unexpected and serious consequences during wake up like a system
-	 * getting stuck in SMI handlers.
-	 * This hack is picked up from Linux, which claims that it follows
-	 * Windows behavior.
-	 */
-	if (sleep_result == 1 && state != ACPI_STATE_S4)
-	    AcpiWriteBitRegister(ACPI_BITREG_SCI_ENABLE, ACPI_ENABLE_EVENT);
-
-	if (sleep_result == 1 && state == ACPI_STATE_S3) {
-	    /*
-	     * Prevent mis-interpretation of the wakeup by power button
-	     * as a request for power off.
-	     * Ideally we should post an appropriate wakeup event,
-	     * perhaps using acpi_event_power_button_wake or alike.
-	     *
-	     * Clearing of power button status after wakeup is mandated
-	     * by ACPI specification in section "Fixed Power Button".
-	     *
-	     * XXX As of ACPICA 20121114 AcpiGetEventStatus provides
-	     * status as 0/1 corressponding to inactive/active despite
-	     * its type being ACPI_EVENT_STATUS.  In other words,
-	     * we should not test for ACPI_EVENT_FLAG_SET for time being.
-	     */
-	    if (ACPI_SUCCESS(AcpiGetEventStatus(ACPI_EVENT_POWER_BUTTON,
-		&power_button_status)) && power_button_status != 0) {
-		AcpiClearEvent(ACPI_EVENT_POWER_BUTTON);
-		device_printf(sc->acpi_dev,
-		    "cleared fixed power button status\n");
-	    }
-	}
-
-	intr_restore(intr);
-
-	/* call acpi_wakeup_machdep() again with interrupt enabled */
-	acpi_wakeup_machdep(sc, state, sleep_result, 1);
-
-	AcpiLeaveSleepStatePrep(state);
-
-	if (sleep_result == -1)
-		goto backout;
-
-	/* Re-enable ACPI hardware on wakeup from sleep state 4. */
-	if (state == ACPI_STATE_S4)
-	    AcpiEnable();
-    } else {
-	status = AcpiEnterSleepState(state);
-	intr_restore(intr);
-	AcpiLeaveSleepStatePrep(state);
-	if (ACPI_FAILURE(status)) {
-	    device_printf(sc->acpi_dev, "AcpiEnterSleepState failed - %s\n",
-			  AcpiFormatException(status));
-	    goto backout;
-	}
+    switch (stype) {
+    case STANDBY:
+	do_standby(sc, &slp_state, intr);
+	break;
+    case SUSPEND:
+    case HIBERNATE:
+	do_sleep(sc, &slp_state, intr, state);
+	break;
+    case SUSPEND_TO_IDLE:
+	do_idle(sc, &slp_state, intr);
+	break;
+    case AWAKE:
+    case POWEROFF:
+    default:
+	__unreachable();
     }
-    slp_state = ACPI_SS_SLEPT;
 
     /*
      * Back out state according to how far along we got in the suspend
@@ -3447,13 +3496,13 @@ backout:
     if (slp_state >= ACPI_SS_SLP_PREP)
 	resumeclock();
     if (slp_state >= ACPI_SS_GPE_SET) {
-	acpi_wake_prep_walk(state);
+	acpi_wake_prep_walk(stype);
 	sc->acpi_sstate = ACPI_STATE_S0;
     }
     if (slp_state >= ACPI_SS_DEV_SUSPEND)
 	DEVICE_RESUME(root_bus);
     if (slp_state >= ACPI_SS_SLP_PREP)
-	AcpiLeaveSleepState(state);
+	AcpiLeaveSleepState(stype);
     if (slp_state >= ACPI_SS_SLEPT) {
 #if defined(__i386__) || defined(__amd64__)
 	/* NB: we are still using ACPI timecounter at this point. */
@@ -3488,7 +3537,7 @@ backout:
 
     /* Run /etc/rc.resume after we are back. */
     if (devctl_process_running())
-	acpi_UserNotify("Resume", ACPI_ROOT_OBJECT, state);
+	acpi_UserNotify("Resume", ACPI_ROOT_OBJECT, stype);
 
     return_ACPI_STATUS (status);
 }

--- a/sys/dev/acpica/acpi.c
+++ b/sys/dev/acpica/acpi.c
@@ -3412,7 +3412,7 @@ do_idle(struct acpi_softc *sc, enum acpi_sleep_state *slp_state,
 
     // TODO Make this better.
     if (sc->acpi_spmc_device != NULL)
-	cpu_mwait(MWAIT_INTRBREAK, MWAIT_C0);
+	cpu_mwait(MWAIT_INTRBREAK, MWAIT_C4);
     else
 	cpu_idle(0);
 

--- a/sys/dev/acpica/acpi_lid.c
+++ b/sys/dev/acpica/acpi_lid.c
@@ -235,9 +235,9 @@ acpi_lid_notify_status_changed(void *arg)
 		sc->lid_status ? "opened" : "closed");
 
     if (sc->lid_status == 0)
-	EVENTHANDLER_INVOKE(acpi_sleep_event, acpi_sc->acpi_lid_switch_sx);
+	EVENTHANDLER_INVOKE(acpi_sleep_event, acpi_sc->acpi_lid_switch_stype);
     else
-	EVENTHANDLER_INVOKE(acpi_wakeup_event, acpi_sc->acpi_lid_switch_sx);
+	EVENTHANDLER_INVOKE(acpi_wakeup_event, acpi_sc->acpi_lid_switch_stype);
 
 out:
     ACPI_SERIAL_END(lid);

--- a/sys/dev/acpica/acpivar.h
+++ b/sys/dev/acpica/acpivar.h
@@ -47,13 +47,22 @@
 #include <machine/bus.h>
 #include <machine/resource.h>
 
+enum sleep_type {
+	AWAKE		= ACPI_STATE_S0,
+	STANDBY		= ACPI_STATE_S1,
+	SUSPEND		= ACPI_STATE_S3,
+	HIBERNATE	= ACPI_STATE_S4,
+	POWEROFF	= ACPI_STATE_S5,
+	SUSPEND_TO_IDLE,
+};
+
 struct apm_clone_data;
 struct acpi_softc {
     device_t		acpi_dev;
     struct cdev		*acpi_dev_t;
 
     int			acpi_enabled;
-    int			acpi_sstate;
+    enum sleep_type	acpi_sstate;
     int			acpi_sleep_disabled;
 
     struct sysctl_ctx_list acpi_sysctl_ctx;
@@ -383,7 +392,7 @@ ACPI_STATUS	acpi_EvaluateOSC(ACPI_HANDLE handle, uint8_t *uuid,
 		    uint32_t *caps_out, bool query);
 ACPI_STATUS	acpi_OverrideInterruptLevel(UINT32 InterruptNumber);
 ACPI_STATUS	acpi_SetIntrModel(int model);
-int		acpi_ReqSleepState(struct acpi_softc *sc, int state);
+int		acpi_ReqSleepState(struct acpi_softc *sc, enum sleep_type stype);
 int		acpi_AckSleepState(struct apm_clone_data *clone, int error);
 ACPI_STATUS	acpi_SetSleepState(struct acpi_softc *sc, int state);
 int		acpi_wake_set_enable(device_t dev, int enable);

--- a/sys/dev/acpica/acpivar.h
+++ b/sys/dev/acpica/acpivar.h
@@ -48,13 +48,23 @@
 #include <machine/resource.h>
 
 enum sleep_type {
-	AWAKE		= ACPI_STATE_S0,
-	STANDBY		= ACPI_STATE_S1,
-	SUSPEND		= ACPI_STATE_S3,
-	HIBERNATE	= ACPI_STATE_S4,
-	POWEROFF	= ACPI_STATE_S5,
-	SUSPEND_TO_IDLE,
+    /*
+     * Map these with ACPI S-states the best we can.  We want to be able to
+     * assign an S-state to an enum sleep_type.  The other way round is
+     * impossible though, as we support additional non-S-state sleep types.
+     */
+    STYPE_AWAKE		= ACPI_STATE_S0,
+    STYPE_STANDBY	= ACPI_STATE_S1,
+    STYPE_STANDBY_S2	= ACPI_STATE_S2,
+    STYPE_SUSPEND	= ACPI_STATE_S3,
+    STYPE_HIBERNATE	= ACPI_STATE_S4,
+    STYPE_POWEROFF	= ACPI_STATE_S5,
+    STYPE_SUSPEND_TO_IDLE,
+    STYPE_COUNT,
+    STYPE_UNKNOWN	= ACPI_STATE_UNKNOWN,
 };
+
+CTASSERT(STYPE_COUNT == 7);
 
 struct apm_clone_data;
 struct acpi_softc {
@@ -62,17 +72,18 @@ struct acpi_softc {
     struct cdev		*acpi_dev_t;
 
     int			acpi_enabled;
-    enum sleep_type	acpi_sstate;
+    enum sleep_type	acpi_stype;
     int			acpi_sleep_disabled;
 
     struct sysctl_ctx_list acpi_sysctl_ctx;
     struct sysctl_oid	*acpi_sysctl_tree;
-    int			acpi_power_button_sx;
-    int			acpi_sleep_button_sx;
-    int			acpi_lid_switch_sx;
+    enum sleep_type	acpi_power_button_stype;
+    enum sleep_type	acpi_sleep_button_stype;
+    enum sleep_type	acpi_lid_switch_stype;
 
-    int			acpi_standby_sx;
-    int			acpi_suspend_sx;
+    enum sleep_type	acpi_standby_stype;
+    enum sleep_type	acpi_suspend_stype;
+    enum sleep_type	acpi_hibernate_stype;
 
     int			acpi_sleep_delay;
     int			acpi_s4bios;
@@ -87,7 +98,7 @@ struct acpi_softc {
     vm_offset_t		acpi_wakeaddr;
     vm_paddr_t		acpi_wakephys;
 
-    int			acpi_next_sstate;	/* Next suspend Sx state. */
+    enum sleep_type	acpi_next_stype;	/* Next suspend sleep type. */
     struct apm_clone_data *acpi_clone;		/* Pseudo-dev for devd(8). */
     STAILQ_HEAD(,apm_clone_data) apm_cdevs;	/* All apm/apmctl/acpi cdevs. */
     struct callout	susp_force_to;		/* Force suspend if no acks. */

--- a/sys/x86/acpica/acpi_apm.c
+++ b/sys/x86/acpica/acpi_apm.c
@@ -236,7 +236,7 @@ apmdtor(void *data)
 	acpi_sc = clone->acpi_sc;
 
 	/* We are about to lose a reference so check if suspend should occur */
-	if (acpi_sc->acpi_next_sstate != 0 &&
+	if (acpi_sc->acpi_next_stype != 0 &&
 	    clone->notify_status != APM_EV_ACKED)
 		acpi_AckSleepState(clone, 0);
 
@@ -284,10 +284,10 @@ apmioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag, struct thread *td
 	case APMIO_SUSPEND:
 		if ((flag & FWRITE) == 0)
 			return (EPERM);
-		if (acpi_sc->acpi_next_sstate == 0) {
-			if (acpi_sc->acpi_suspend_sx != ACPI_STATE_S5) {
+		if (acpi_sc->acpi_next_stype == 0) {
+			if (acpi_sc->acpi_suspend_stype != ACPI_STATE_S5) {
 				error = acpi_ReqSleepState(acpi_sc,
-				    acpi_sc->acpi_suspend_sx);
+				    acpi_sc->acpi_suspend_stype);
 			} else {
 				printf(
 			"power off via apm suspend not supported\n");
@@ -299,10 +299,10 @@ apmioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag, struct thread *td
 	case APMIO_STANDBY:
 		if ((flag & FWRITE) == 0)
 			return (EPERM);
-		if (acpi_sc->acpi_next_sstate == 0) {
-			if (acpi_sc->acpi_standby_sx != ACPI_STATE_S5) {
+		if (acpi_sc->acpi_next_stype == 0) {
+			if (acpi_sc->acpi_standby_stype != ACPI_STATE_S5) {
 				error = acpi_ReqSleepState(acpi_sc,
-				    acpi_sc->acpi_standby_sx);
+				    acpi_sc->acpi_standby_stype);
 			} else {
 				printf(
 			"power off via apm standby not supported\n");
@@ -314,10 +314,10 @@ apmioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flag, struct thread *td
 	case APMIO_NEXTEVENT:
 		printf("apm nextevent start\n");
 		ACPI_LOCK(acpi);
-		if (acpi_sc->acpi_next_sstate != 0 && clone->notify_status ==
+		if (acpi_sc->acpi_next_stype != 0 && clone->notify_status ==
 		    APM_EV_NONE) {
 			ev_info = (struct apm_event_info *)addr;
-			if (acpi_sc->acpi_next_sstate <= ACPI_STATE_S3)
+			if (acpi_sc->acpi_next_stype <= ACPI_STATE_S3)
 				ev_info->type = PMEV_STANDBYREQ;
 			else
 				ev_info->type = PMEV_SUSPENDREQ;
@@ -393,7 +393,7 @@ apmpoll(struct cdev *dev, int events, struct thread *td)
 	revents = 0;
 	devfs_get_cdevpriv((void **)&clone);
 	ACPI_LOCK(acpi);
-	if (clone->acpi_sc->acpi_next_sstate)
+	if (clone->acpi_sc->acpi_next_stype)
 		revents |= events & (POLLIN | POLLRDNORM);
 	else
 		selrecord(td, &clone->sel_read);
@@ -434,7 +434,7 @@ apmreadfilt(struct knote *kn, long hint)
 
 	ACPI_LOCK(acpi);
 	clone = kn->kn_hook;
-	sleeping = clone->acpi_sc->acpi_next_sstate ? 1 : 0;
+	sleeping = clone->acpi_sc->acpi_next_stype ? 1 : 0;
 	ACPI_UNLOCK(acpi);
 	return (sleeping);
 }

--- a/sys/x86/include/intr_machdep.h
+++ b/sys/x86/include/intr_machdep.h
@@ -152,6 +152,7 @@ int	intr_register_source(struct intsrc *isrc);
 int	intr_remove_handler(void *cookie);
 void	intr_resume(bool suspend_cancelled);
 void	intr_suspend(void);
+void	intr_enable_src(u_int irq);
 void	intr_reprogram(void);
 void	intrcnt_add(const char *name, u_long **countp);
 void	nexus_add_irq(u_long irq);

--- a/sys/x86/x86/intr_machdep.c
+++ b/sys/x86/x86/intr_machdep.c
@@ -392,6 +392,15 @@ intr_suspend(void)
 	mtx_unlock(&intrpic_lock);
 }
 
+void
+intr_enable_src(u_int irq)
+{
+	struct intsrc *is;
+
+	is = interrupt_sources[irq];
+	is->is_pic->pic_enable_source(is);
+}
+
 static int
 intr_assign_cpu(void *arg, int cpu)
 {

--- a/usr.sbin/acpi/acpiconf/acpiconf.c
+++ b/usr.sbin/acpi/acpiconf/acpiconf.c
@@ -38,6 +38,7 @@
 #include <unistd.h>
 
 #include <dev/acpica/acpiio.h>
+#include <dev/acpica/acpivar.h>
 
 #include <contrib/dev/acpica/include/acpi.h>
 
@@ -258,6 +259,11 @@ main(int argc, char *argv[])
 			break;
 		case 's':
 			sflag = 1;
+			if (strcmp(optarg, "SUSPEND_TO_IDLE") == 0 ||
+			    strcmp(optarg, "S2IDLE") == 0) {
+			    sleep_type = SUSPEND_TO_IDLE;
+			    break;
+			}
 			if (optarg[0] == 'S')
 				optarg++;
 			sleep_type = strtol(optarg, &end, 10);

--- a/usr.sbin/acpi/acpiconf/acpiconf.c
+++ b/usr.sbin/acpi/acpiconf/acpiconf.c
@@ -259,9 +259,8 @@ main(int argc, char *argv[])
 			break;
 		case 's':
 			sflag = 1;
-			if (strcmp(optarg, "SUSPEND_TO_IDLE") == 0 ||
-			    strcmp(optarg, "S2IDLE") == 0) {
-			    sleep_type = SUSPEND_TO_IDLE;
+			if (strcmp(optarg, "S0i") == 0) {
+			    sleep_type = STYPE_SUSPEND_TO_IDLE;
 			    break;
 			}
 			if (optarg[0] == 'S')

--- a/usr.sbin/acpi/acpiconf/acpiconf.c
+++ b/usr.sbin/acpi/acpiconf/acpiconf.c
@@ -38,7 +38,6 @@
 #include <unistd.h>
 
 #include <dev/acpica/acpiio.h>
-#include <dev/acpica/acpivar.h>
 
 #include <contrib/dev/acpica/include/acpi.h>
 
@@ -259,10 +258,6 @@ main(int argc, char *argv[])
 			break;
 		case 's':
 			sflag = 1;
-			if (strcmp(optarg, "S0i") == 0) {
-			    sleep_type = STYPE_SUSPEND_TO_IDLE;
-			    break;
-			}
 			if (optarg[0] == 'S')
 				optarg++;
 			sleep_type = strtol(optarg, &end, 10);


### PR DESCRIPTION
I would like to split this up into:

- Using stypes everywhere instead of sstates (doesn't depend on anything).
- Actually bringing out the `do_*` functions and adding S0i, w/ the SPMC callback calling (so depends on the SPMC revision).
- The upcoming SMU patch in #7 depends on this.
- Then, I can work on last wake event and S0i loop patches, depending on the previous one.

Actually, I could make calling the SPMC callbacks its own thing, which would allow me to do the S0i loop and last wake event stuff separately.